### PR TITLE
Create Custom 404 Page

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use App\Http\Middleware\RoleMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -17,5 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        $exceptions->renderable(function (NotFoundHttpException $e, $request) {
+            return response()->view('errors.404', [], 404);
+        });
     })->create();

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page Not Found</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+
+<body class="d-flex align-items-center justify-content-center vh-100">
+    <div class="text-center">
+        <h1 class="display-1 fw-bold text-danger">404</h1>
+        <p class="fs-3"><span class="text-danger">Oops!</span> Page not found.</p>
+        <p class="lead">The page you are looking for might have been removed or is temporarily unavailable.</p>
+        <a href="{{ url('/') }}" class="btn btn-primary">Go to Homepage</a>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
# Feature add custom 404 error page and handle NotFoundHttpException

## Description

This feature implements a custom 404 error page to replace the default Laravel "Page Not Found" error page. The custom 404 page provides a more user-friendly experience with a consistent design, guiding users back to the homepage or other relevant sections when they encounter a "Not Found" error.


## Changes Made

- Updated the bootstrap/app.php file to configure the exception handler to render a custom 404 page (errors.404).
- Created a custom 404 error page view (resources/views/errors/404.blade.php) that includes a friendly message and a link to return to the homepage.
- Updated exception handling to catch the NotFoundHttpException and display the custom 404 page instead of the default Laravel error page.


## Purpose

- Enhance the user experience by providing a more visually appealing and informative 404 error page.
- Maintain consistency with the overall design and branding of the application.
- Improve navigation by including a direct link to return to the homepage, reducing user frustration when encountering broken links or non-existing pages.


## Testing

- Manually tested by visiting a non-existing URL in the browser (e.g., http://localhost/invalid-url) to confirm the custom 404 page is rendered correctly.
- Verified that clicking the "Go Home" button redirects to the homepage (/).
- Ensured the application no longer shows the default Laravel error page for 404 errors.
- 

## Related Issues

This pull request addresses [#33 ].

## Proof of Changes

![image](https://github.com/user-attachments/assets/7adc8e8c-deaa-43aa-9b0e-9d94c2852eef)